### PR TITLE
Update .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,4 +5,4 @@ name = "go"
 enabled = true
 
   [analyzers.meta]
-  import_paths = ["github.com/subham-deepsource/tidb"]
+  import_paths = ["github.com/pingcap/tidb"]

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,4 +5,4 @@ name = "go"
 enabled = true
 
   [analyzers.meta]
-  import_paths = ["github.com/zz-jason/tidb"]
+  import_paths = ["github.com/subham-deepsource/tidb"]


### PR DESCRIPTION
Hey 👋 

I'm from the DeepSource team and we see some of the functionalities of our analyzer failing for your repo and we noticed that it was due to incorrect configuration (`.deepsource.toml`). It just requires a simple change i.e., update the `import_paths` to the module path.

Thank you for using DeepSource.

### What problem does this PR solve?
Problem Summary: After the fork, module path didn't update and it's still `github.com/pingcap/tidb` instead of `github.com/zz-jason/tidb`.  But the `.deepsource.toml` did have incorrect `import_paths` because module path didn't change.

### What is changed and how it works?



What's Changed:

- Update the `import_paths` in `.deepsource.toml` by `github.com/pingcap/tidb`
